### PR TITLE
Adding iOS Storyboard file as an extension

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -9,6 +9,7 @@
   'rss'
   'opml'
   'svg'
+  'storyboard'
 ]
 'name': 'XML'
 'patterns': [


### PR DESCRIPTION
Storyboard files are basically XML files and it would be nice to get proper highlighting.
