### PR TITLE
Updated xml.cson to support XLIFF

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -14,6 +14,8 @@
   'wsdl'
   'rdf'
   'isml'
+  'xlf'
+  'xliff'
 ]
 'name': 'XML'
 'patterns': [


### PR DESCRIPTION
XLIFF is an XML-based format created to standardize the way localizable data are passed between tools during a localization process, according to [Wikipedia](http://en.wikipedia.org/wiki/XLIFF). The main extension is `.xlf`, but some tools are using `.xliff` (the Symfony2 translator for example). So these two extensions should be supported as part of the standard XML grammar.
