### PR TITLE
Snippets changes to tags.

### DIFF
--- a/snippets/language-xml.cson
+++ b/snippets/language-xml.cson
@@ -7,10 +7,10 @@
     'body': '<?xml version="1.0" encoding="UTF-8"?>'
   'Long Attribute Tag':
     'prefix': '<a'
-    'body': '<${1:name} ${2:attr="value"}>$4\n</${3:name}>'
+    'body': '<${1:name} ${2:attr}="${3:value}">$4\n</${1:name}>'
   'Long Tag':
     'prefix': '<'
-    'body': '<${1:name}>$3</${2:name}>'
+    'body': '<${1:name}>$2</${1:name}>'
   'Short Tag':
     'prefix': '>'
     'body': '<${1:name} />'


### PR DESCRIPTION
Long Tag: Changed opening and closing tags to use the same substituted parameter, as these values should be the same, and this will reduce typing.
Long Attribute Tag: Changed opening and closing tags in line with Long Tab and separated the attribute name and value to each have their own substituted parameter.
