### PR TITLE
Add dot character highlighting in XML tags

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -122,7 +122,7 @@
     ]
   }
   {
-    'begin': '(</?)(?:([-_a-zA-Z0-9]+)((:)))?([-_a-zA-Z0-9:]+)'
+    'begin': '(</?)(?:([-\\w\\.]+)((:)))?([-\\w\\.:]+)'
     'captures':
       '1':
         'name': 'punctuation.definition.tag.xml'


### PR DESCRIPTION
Added a dot (.) character for the XML tag highlighting so that atom properly highlights tags like 

```
<ootb.version>1.0-SNAPSHOT</ootb.version>
```

and also replaced `[a-zA-Z0-9_]` group with `\w`
