### PR TITLE
:bug: fix regex for meta.tag.no-content.xml

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -91,33 +91,31 @@
     'name': 'comment.block.xml'
   }
   {
-    'begin': '(<)((?:([-_a-zA-Z0-9]+)((:)))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)'
+    'begin': '(<)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.xml'
+      '2':
+        'name': 'entity.name.tag.xml'
       '3':
         'name': 'entity.name.tag.namespace.xml'
       '4':
-        'name': 'entity.name.tag.xml'
-      '5':
         'name': 'punctuation.separator.namespace.xml'
-      '6':
+      '5':
         'name': 'entity.name.tag.localname.xml'
-    'end': '(>(<))/(?:([-_a-zA-Z0-9]+)((:)))?([-_a-zA-Z0-9:]+)(>)'
+    'end': '(></)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.tag.xml'
       '2':
-        'name': 'meta.scope.between-tag-pair.xml'
+        'name': 'entity.name.tag.xml'
       '3':
         'name': 'entity.name.tag.namespace.xml'
       '4':
-        'name': 'entity.name.tag.xml'
-      '5':
         'name': 'punctuation.separator.namespace.xml'
-      '6':
+      '5':
         'name': 'entity.name.tag.localname.xml'
-      '7':
+      '6':
         'name': 'punctuation.definition.tag.xml'
     'name': 'meta.tag.no-content.xml'
     'patterns': [


### PR DESCRIPTION
Incorrect captures in case of `<test></test>` — the `/` char does not belong to any group what breaks highlighting.
![atom-xml-highlight-bug](https://cloud.githubusercontent.com/assets/2678296/8068023/01f7dd70-0efa-11e5-9064-959d21924a7e.png)

