### PR TITLE
Add support for `.menu` files. Fixes #37

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -17,6 +17,7 @@
   'isml'
   'jsp'
   'launch'
+  'menu'
   'mxml'
   'nuspec'
   'opml'


### PR DESCRIPTION
Adds `.menu` to the list of files matched as XML files. This fixes #37.