### PR TITLE
Fix incorrect highlighting for empty element

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -107,19 +107,21 @@
         'name': 'punctuation.separator.namespace.xml'
       '5':
         'name': 'entity.name.tag.localname.xml'
-    'end': '(></)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)'
+    'end': '(>)(</)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.tag.xml'
       '2':
-        'name': 'entity.name.tag.xml'
+        'name': 'punctuation.definition.tag.xml'
       '3':
-        'name': 'entity.name.tag.namespace.xml'
+        'name': 'entity.name.tag.xml'
       '4':
-        'name': 'punctuation.separator.namespace.xml'
+        'name': 'entity.name.tag.namespace.xml'
       '5':
-        'name': 'entity.name.tag.localname.xml'
+        'name': 'punctuation.separator.namespace.xml'
       '6':
+        'name': 'entity.name.tag.localname.xml'
+      '7':
         'name': 'punctuation.definition.tag.xml'
     'name': 'meta.tag.no-content.xml'
     'patterns': [

--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -95,33 +95,31 @@
     'include': '#comments'
   }
   {
-    'begin': '(<)((?:([-_a-zA-Z0-9]+)((:)))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)'
+    'begin': '(<)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)'
     'beginCaptures':
       '1':
         'name': 'punctuation.definition.tag.xml'
+      '2':
+        'name': 'entity.name.tag.xml'
       '3':
         'name': 'entity.name.tag.namespace.xml'
       '4':
-        'name': 'entity.name.tag.xml'
-      '5':
         'name': 'punctuation.separator.namespace.xml'
-      '6':
+      '5':
         'name': 'entity.name.tag.localname.xml'
-    'end': '(>(<))/(?:([-_a-zA-Z0-9]+)((:)))?([-_a-zA-Z0-9:]+)(>)'
+    'end': '(></)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)'
     'endCaptures':
       '1':
         'name': 'punctuation.definition.tag.xml'
       '2':
-        'name': 'meta.scope.between-tag-pair.xml'
+        'name': 'entity.name.tag.xml'
       '3':
         'name': 'entity.name.tag.namespace.xml'
       '4':
-        'name': 'entity.name.tag.xml'
-      '5':
         'name': 'punctuation.separator.namespace.xml'
-      '6':
+      '5':
         'name': 'entity.name.tag.localname.xml'
-      '7':
+      '6':
         'name': 'punctuation.definition.tag.xml'
     'name': 'meta.tag.no-content.xml'
     'patterns': [

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -24,3 +24,11 @@ describe "XML grammar", ->
     expect(lines[1][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(lines[2][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(lines[3][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
+
+  it "tokenizes empty element meta.tag.no-content.xml", ->
+    {tokens} = grammar.tokenizeLine('<n></n>')
+    expect(tokens[0]).toEqual value: '<',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']
+    expect(tokens[1]).toEqual value: 'n',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'entity.name.tag.xml', 'entity.name.tag.localname.xml']
+    expect(tokens[2]).toEqual value: '></', scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']
+    expect(tokens[3]).toEqual value: 'n',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'entity.name.tag.xml', 'entity.name.tag.localname.xml']
+    expect(tokens[4]).toEqual value: '>',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -29,6 +29,7 @@ describe "XML grammar", ->
     {tokens} = grammar.tokenizeLine('<n></n>')
     expect(tokens[0]).toEqual value: '<',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']
     expect(tokens[1]).toEqual value: 'n',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'entity.name.tag.xml', 'entity.name.tag.localname.xml']
-    expect(tokens[2]).toEqual value: '></', scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']
-    expect(tokens[3]).toEqual value: 'n',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'entity.name.tag.xml', 'entity.name.tag.localname.xml']
-    expect(tokens[4]).toEqual value: '>',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']
+    expect(tokens[2]).toEqual value: '>',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']
+    expect(tokens[3]).toEqual value: '</',  scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']
+    expect(tokens[4]).toEqual value: 'n',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'entity.name.tag.xml', 'entity.name.tag.localname.xml']
+    expect(tokens[5]).toEqual value: '>',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']


### PR DESCRIPTION
In case of element is empty (e.g. `<test></test>`) — the `/` char does not belong to any group and it breaks highlighting.

![atom-xml-highlight-bug](https://cloud.githubusercontent.com/assets/2678296/8068023/01f7dd70-0efa-11e5-9064-959d21924a7e.png)

To solve this issue the regex for capturing meta.tag.no-content.xml is fixed.

Also the spec for this case is added.