### PR TITLE
Add .dae (COLLADA) to recognised XML types

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -9,6 +9,7 @@
   'csl'
   'csproj'
   'csproj.user'
+  'dae'
   'dita'
   'ditamap'
   'dtml'


### PR DESCRIPTION
[COLLADA](https://en.wikipedia.org/wiki/COLLADA) is a standardised 3D interchange format that uses an XML-based schema to describe data, suffixed with the `.dae` file extension.

That's pretty much all.