### PR TITLE
Add .ppj to recognized file types

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -27,6 +27,7 @@
   'nuspec'
   'opml'
   'owl'
+  'ppj'
   'proj'
   'pt'
   'pubxml'


### PR DESCRIPTION
This adds .ppj to the known file types. PPJ files are Papyrus Project files, used by the Papyrus Compiler for Fallout 4.