### PR TITLE
Add glade to list of xml file types

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -15,6 +15,7 @@
   'dtml'
   'fsproj'
   'fxml'
+  'glade'
   'gpx'
   'icls'
   'iml'


### PR DESCRIPTION
`.glade` files are files used to specify the layout of Gtk Applications in XML format and as such should be considered xml files in Atom.