### PR TITLE
Added VirtualBox file types to xml file types.

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -41,6 +41,8 @@
   'svg'
   'targets'
   'tld'
+  'vbox'
+  'vbox-prev'
   'vbproj'
   'vbproj.user'
   'vcproj'


### PR DESCRIPTION
Oracle VirtualBox uses their own `.vbox` and `.vbox-prev` files for the settings of virtual machines, which are in an apparent XML format. Sometimes it is necessary to manually add attributes that are not officially supported (e.g. `discard="true"` for immediate SSD garbage collection).