### PR TITLE
conform to w3c specs of attribute-name

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -327,7 +327,7 @@
             'name': 'punctuation.separator.namespace.xml'
           '4':
             'name': 'entity.other.attribute-name.localname.xml'
-        'match': '(?:^|\\s+)(?:([-_a-zA-Z0-9]+)((:)))?([-_a-zA-Z0-9]+)='
+        'match': '(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)='
       }
       {
         'include': '#doublequotedString'

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -48,3 +48,38 @@ attrName="attrValue">
       </el>
     """
     expect(linesWithoutIndent[1][0]).toEqual value: 'attrName', scopes: ['text.xml', 'meta.tag.xml', 'entity.other.attribute-name.localname.xml']
+
+  it "tokenizes attribute-name.namespace contains period", ->
+    lines = grammar.tokenizeLines """
+      <el name.space:attrName="attrValue">
+      </el>
+    """
+    expect(lines[0][3]).toEqual value: 'name.space', scopes: ['text.xml', 'meta.tag.xml', 'entity.other.attribute-name.namespace.xml']
+
+  it "tokenizes attribute-name.namespace contains East-Asian Kanji", ->
+    lines = grammar.tokenizeLines """
+      <el 名前空間名:attrName="attrValue">
+      </el>
+    """
+    expect(lines[0][3]).toEqual value: '名前空間名', scopes: ['text.xml', 'meta.tag.xml', 'entity.other.attribute-name.namespace.xml']
+
+  it "tokenizes attribute-name.localname contains period", ->
+    lines = grammar.tokenizeLines """
+      <el attr.name="attrValue">
+      </el>
+    """
+    expect(lines[0][3]).toEqual value: 'attr.name', scopes: ['text.xml', 'meta.tag.xml', 'entity.other.attribute-name.localname.xml']
+
+  it "tokenizes attribute-name.localname contains colon", ->
+    lines = grammar.tokenizeLines """
+      <el namespace:attr:name="attrValue">
+      </el>
+    """
+    expect(lines[0][5]).toEqual value: 'attr:name', scopes: ['text.xml', 'meta.tag.xml', 'entity.other.attribute-name.localname.xml']
+
+  it "tokenizes attribute-name.localname contains East-Asian Kanji", ->
+    lines = grammar.tokenizeLines """
+      <el 属性名="attrValue">
+      </el>
+    """
+    expect(lines[0][3]).toEqual value: '属性名', scopes: ['text.xml', 'meta.tag.xml', 'entity.other.attribute-name.localname.xml']


### PR DESCRIPTION
actually we can use more chars for attr names.
especially period `.` is heavily used on Microsoft XAML file([Attached Properties Overview - Attached Properties in XAML](https://msdn.microsoft.com/en-us/library/ms749011(v=vs.110).aspx#Anchor_2)).
so please check this pr. thanks

# References

- [Extensible Markup Language \(XML\) 1\.0 \(Fifth Edition\) - Names and Tokens](https://www.w3.org/TR/2008/REC-xml-20081126/#d0e804)
- [Extensible Markup Language \(XML\) 1\.1 \(Second Edition\) - Names and Tokens](https://www.w3.org/TR/2006/REC-xml11-20060816/#IDAKUDS)
- [Namespaces in XML 1\.0 \(Second Edition\) - Attribute Names for Namespace Declaration](https://www.w3.org/TR/2006/REC-xml-names-20060816/#A737)
- [Namespaces in XML 1\.1 \(Second Edition\) - Attribute Names for Namespace Declaration](https://www.w3.org/TR/2006/REC-xml-names11-20060816/#A919)