### PR TITLE
Add language support for SDF files

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -67,6 +67,7 @@
   'xsd'
   'xul'
   'ui'
+  'sdf'
 ]
 'patterns': [
   {

--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -43,6 +43,7 @@
   'rdf'
   'rng'
   'rss'
+  'sdf'
   'shproj'
   'storyboard'
   'svg'
@@ -67,7 +68,6 @@
   'xsd'
   'xul'
   'ui'
-  'sdf'
 ]
 'patterns': [
   {


### PR DESCRIPTION
Hello, this pull request is to consider the possible support of Simulation Description Format (SDF) files.

[SDF](http://sdformat.org) is (I quote):
> an XML format that describes objects and environments for robot simulators, visualization, and control.

Full specification of an SDF file can be found [here](http://sdformat.org/spec).