### PR TITLE
Apply grammar to any file starting with an XML declaration

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -76,6 +76,40 @@
   'xul'
   'ui'
 ]
+'firstLineMatch': '''(?x)
+  ^ <\\? xml
+
+  # VersionInfo
+  \\s+ version
+  \\s* = \\s*
+  ([\'"])
+    1 \\. [0-9]+
+  \\1
+
+  # EncodingDecl
+  (?:
+    \\s+ encoding
+    \\s* = \\s*
+
+    # EncName
+    ([\'"])
+      [A-Za-z]
+      [-A-Za-z0-9._]*
+    \\2
+  )?
+
+  # SDDecl
+  (?:
+    \\s+ standalone
+    \\s* = \\s*
+    ([\'"])
+      (?:yes|no)
+    \\3
+  )?
+
+  \\s*
+  \\?>
+'''
 'patterns': [
   {
     'begin': '(<\\?)\\s*([-_a-zA-Z0-9]+)'

--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -77,38 +77,53 @@
   'ui'
 ]
 'firstLineMatch': '''(?x)
-  ^ <\\? xml
-
-  # VersionInfo
-  \\s+ version
-  \\s* = \\s*
-  ([\'"])
-    1 \\. [0-9]+
-  \\1
-
-  # EncodingDecl
+  # XML declaration
   (?:
-    \\s+ encoding
-    \\s* = \\s*
+    ^ <\\? xml
 
-    # EncName
-    ([\'"])
-      [A-Za-z]
-      [-A-Za-z0-9._]*
-    \\2
-  )?
-
-  # SDDecl
-  (?:
-    \\s+ standalone
+    # VersionInfo
+    \\s+ version
     \\s* = \\s*
     ([\'"])
-      (?:yes|no)
-    \\3
-  )?
+      1 \\. [0-9]+
+    \\1
 
-  \\s*
-  \\?>
+    # EncodingDecl
+    (?:
+      \\s+ encoding
+      \\s* = \\s*
+
+      # EncName
+      ([\'"])
+        [A-Za-z]
+        [-A-Za-z0-9._]*
+      \\2
+    )?
+
+    # SDDecl
+    (?:
+      \\s+ standalone
+      \\s* = \\s*
+      ([\'"])
+        (?:yes|no)
+      \\3
+    )?
+
+    \\s* \\?>
+  )
+  |
+  # Modeline
+  (?i:
+    # Emacs
+    -\\*-(?:\\s*(?=[^:;\\s]+\\s*-\\*-)|(?:.*?[;\\s]|(?<=-\\*-))mode\\s*:\\s*)
+      xml
+    (?=[\\s;]|(?<![-*])-\\*-).*?-\\*-
+    |
+    # Vim
+    (?:(?:\\s|^)vi(?:m[<=>]?\\d+|m)?|\\sex)(?=:(?=\\s*set?\\s[^\\n:]+:)|:(?!\\s*set?\\s))(?:(?:\\s|\\s*:\\s*)\\w*(?:\\s*=(?:[^\\n\\\\\\s]|\\\\.)*)?)*[\\s:](?:filetype|ft|syntax)\\s*=
+      xml
+    (?=\\s|:|$)
+  )
 '''
 'patterns': [
   {


### PR DESCRIPTION
### Description of the Change

This PR adds XML highlighting to any file beginning with a [valid XML declaration](https://www.w3.org/TR/xml/#sec-prolog-dtd):

~~~xml
<?xml version="1.0" encoding="UTF-8"?>
~~~

It also adds recognition for Emacs and Vim modelines:

~~~xml
<!-- -*- XML -*- -->
<!-- vim: set filetype=XML: -->
~~~

### Benefits

There are likely many more XML-based file formats out there which this package doesn't recognise. Most of them start with an XML declaration.


### Possible Drawbacks

It's possible this grammar might be activated instead of [`language-property-list`](https://github.com/atom/language-property-list) when opening a `.plist` file. Since that grammar already includes a [`firstLineMatch`](https://github.com/atom/language-property-list/blob/master/grammars/property%20list%20(xml).cson#L8) as well, it probably won't be an issue.