### PR TITLE
Added 2 extensions to xml.cson

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -1,6 +1,7 @@
 'scopeName': 'text.xml'
 'name': 'XML'
 'fileTypes': [
+  'aiml'
   'atom'
   'axml'
   'bpmn'
@@ -47,6 +48,7 @@
   'rss'
   'sdf'
   'shproj'
+  'siml'
   'sld'
   'storyboard'
   'svg'


### PR DESCRIPTION
I added 2 extensions to the list to support .aiml  and .siml fileTypes.

Both AIML (Artificial Intelligence Markup Language) and SIML (Synthetic Intelligence Markup Language) are XML-compliant languages used in the creation of programs capable to understand natural language.

This will help people writing in those languages without having to resort to hacky workarounds to make Atom correctly highlight tags.