### PR TITLE
allow space after attribute name, associated spec

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -387,7 +387,7 @@
             'name': 'punctuation.separator.namespace.xml'
           '4':
             'name': 'entity.other.attribute-name.localname.xml'
-        'match': '(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+) *='
+        'match': '(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*='
       }
       {
         'include': '#doublequotedString'

--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -387,7 +387,7 @@
             'name': 'punctuation.separator.namespace.xml'
           '4':
             'name': 'entity.other.attribute-name.localname.xml'
-        'match': '(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)='
+        'match': '(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+) *='
       }
       {
         'include': '#doublequotedString'

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -33,7 +33,7 @@ describe "XML grammar", ->
     expect(tokens[3]).toEqual value: '</',  scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']
     expect(tokens[4]).toEqual value: 'n',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'entity.name.tag.xml', 'entity.name.tag.localname.xml']
     expect(tokens[5]).toEqual value: '>',   scopes: ['text.xml', 'meta.tag.no-content.xml', 'punctuation.definition.tag.xml']
-    
+
   it "tokenizes attribute-name of multi-line tag", ->
     linesWithIndent = grammar.tokenizeLines """
       <el
@@ -83,6 +83,13 @@ attrName="attrValue">
       </el>
     """
     expect(lines[0][3]).toEqual value: '属性名', scopes: ['text.xml', 'meta.tag.xml', 'entity.other.attribute-name.localname.xml']
+
+  it "tokenizes attribute-name.localname when followed by spaces", ->
+    lines = grammar.tokenizeLines """
+      <el attrName     ="attrValue">
+      </el>
+    """
+    expect(lines[0][3]).toEqual value: 'attrName', scopes: ['text.xml', 'meta.tag.xml', 'entity.other.attribute-name.localname.xml']
 
   describe "firstLineMatch", ->
     it "recognises Emacs modelines", ->


### PR DESCRIPTION
### Description of the Change

Added space after attributes, to fix bug #81 

### Benefits

Improved XML grammer
