### PR TITLE
add snippet for long tag with body

### DIFF
--- a/snippets/language-xml.cson
+++ b/snippets/language-xml.cson
@@ -8,6 +8,9 @@
   'Long Attribute Tag':
     'prefix': '<a'
     'body': '<${1:name} ${2:attr}="${3:value}">$4\n</${1:name}>'
+  'Long tag w/ Body':
+    'prefix': '<b'
+    'body': '<${1:name}>\n\t$2\n</${1:name}>$3'
   'Long Tag':
     'prefix': '<'
     'body': '<${1:name}>$2</${1:name}>'


### PR DESCRIPTION
### Description of the Change

This change adds a new snippet to for creating a long, XML tag with a body

### Benefits

As most XML elements contain a body, this makes it easier to quickly create the surrounding tags and tab into the body.

### Possible Drawbacks


### Applicable Issues

