### PR TITLE
Forbid comments with more than two dashes

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -397,15 +397,29 @@
       }
     ]
   'comments':
-    'begin': '<[!%]--'
-    'captures':
-      '0':
-        'name': 'punctuation.definition.comment.xml'
-    'end': '--%?>'
-    'name': 'comment.block.xml'
     'patterns': [
       {
-        'match': '(?<!<[!%])--(?!>)'
-        'name': 'invalid.illegal.bad-comments-or-CDATA.xml'
+        'begin': '<%--'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.xml'
+          'end': '--%>'
+          'name': 'comment.block.xml'
+      }
+      {
+        'begin': '<!--'
+        'captures':
+          '0':
+            'name': 'punctuation.definition.comment.xml'
+        'end': '-->'
+        'name': 'comment.block.xml'
+        'patterns': [
+          {
+            'begin': '--(?!>)'
+            'captures':
+              '0':
+                'name': 'invalid.illegal.bad-comments-or-CDATA.xml'
+          }
+        ]
       }
     ]

--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -403,3 +403,9 @@
         'name': 'punctuation.definition.comment.xml'
     'end': '--%?>'
     'name': 'comment.block.xml'
+    'patterns': [
+      {
+        'match': '-{3,}>'
+        'name': 'invalid.illegal.bad-comments-or-CDATA.xml'
+      }
+    ]

--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -405,7 +405,7 @@
     'name': 'comment.block.xml'
     'patterns': [
       {
-        'match': '-{3,}>'
+        'match': '(?<!<[!%])--(?!>)'
         'name': 'invalid.illegal.bad-comments-or-CDATA.xml'
       }
     ]

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -24,12 +24,20 @@ describe "XML grammar", ->
     expect(lines[1][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(lines[2][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(lines[3][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
- 
-  it 'tokenizes comments with three dashes as invalid', ->
+
+  it 'tokenizes comment endings with more than two dashes as invalid', ->
     {tokens} = grammar.tokenizeLine('<!-- invalid comment --->')
     expect(tokens[0]).toEqual value: '<!--', scopes: ['text.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(tokens[1]).toEqual value: ' invalid comment ', scopes: ['text.xml', 'comment.block.xml']
-    expect(tokens[2]).toEqual value: '--->', scopes: ['text.xml', 'comment.block.xml', 'invalid.illegal.bad-comments-or-CDATA.xml']
+    expect(tokens[2]).toEqual value: '--', scopes: ['text.xml', 'comment.block.xml', 'invalid.illegal.bad-comments-or-CDATA.xml']
+
+  it 'tokenizes comments with two dashes not followed by ">"', ->
+    {tokens} = grammar.tokenizeLine('<!-- invalid -- comment -->')
+    expect(tokens[0]).toEqual value: '<!--', scopes: ['text.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
+    expect(tokens[1]).toEqual value: ' invalid ', scopes: ['text.xml', 'comment.block.xml']
+    expect(tokens[2]).toEqual value: '--', scopes: ['text.xml', 'comment.block.xml', 'invalid.illegal.bad-comments-or-CDATA.xml']
+    expect(tokens[3]).toEqual value: ' comment ', scopes: ['text.xml', 'comment.block.xml']
+    expect(tokens[4]).toEqual value: '-->', scopes: ['text.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
 
   it "tokenizes empty element meta.tag.no-content.xml", ->
     {tokens} = grammar.tokenizeLine('<n></n>')
@@ -47,7 +55,7 @@ describe "XML grammar", ->
       </el>
     """
     expect(linesWithIndent[1][1]).toEqual value: 'attrName', scopes: ['text.xml', 'meta.tag.xml', 'entity.other.attribute-name.localname.xml']
-    
+
     linesWithoutIndent = grammar.tokenizeLines """
       <el
 attrName="attrValue">

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -24,6 +24,13 @@ describe "XML grammar", ->
     expect(lines[1][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(lines[2][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(lines[3][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
+ 
+    it 'tokenizes comments with three dashes as invalid', ->
+      {tokens} = grammar.tokenizeLine '<!-- invalid comment --->'
+
+      expect(tokens[0]).toEqual value: '<!--', scopes: ['text.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
+      expect(tokens[1]).toEqual value: ' invalid comment ', scopes: ['text.xml', 'comment.block.xml']
+      expect(tokens[2]).toEqual value: '--->', scopes: ['text.xml', 'comment.block.xml', 'invalid.illegal.bad-comments-or-CDATA.xml']
 
   it "tokenizes empty element meta.tag.no-content.xml", ->
     {tokens} = grammar.tokenizeLine('<n></n>')

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -25,7 +25,7 @@ describe "XML grammar", ->
     expect(lines[2][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(lines[3][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
 
-   it 'tokenizes comment endings with more than two dashes as invalid', ->
+  it 'tokenizes comment endings with more than two dashes as invalid', ->
     {tokens} = grammar.tokenizeLine('<!-- invalid comment --->')
     expect(tokens[0]).toEqual value: '<!--', scopes: ['text.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(tokens[1]).toEqual value: ' invalid comment ', scopes: ['text.xml', 'comment.block.xml']

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -25,12 +25,11 @@ describe "XML grammar", ->
     expect(lines[2][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(lines[3][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
  
-    it 'tokenizes comments with three dashes as invalid', ->
-      {tokens} = grammar.tokenizeLine '<!-- invalid comment --->'
-
-      expect(tokens[0]).toEqual value: '<!--', scopes: ['text.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
-      expect(tokens[1]).toEqual value: ' invalid comment ', scopes: ['text.xml', 'comment.block.xml']
-      expect(tokens[2]).toEqual value: '--->', scopes: ['text.xml', 'comment.block.xml', 'invalid.illegal.bad-comments-or-CDATA.xml']
+  it 'tokenizes comments with three dashes as invalid', ->
+    {tokens} = grammar.tokenizeLine('<!-- invalid comment --->')
+    expect(tokens[0]).toEqual value: '<!--', scopes: ['text.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
+    expect(tokens[1]).toEqual value: ' invalid comment ', scopes: ['text.xml', 'comment.block.xml']
+    expect(tokens[2]).toEqual value: '--->', scopes: ['text.xml', 'comment.block.xml', 'invalid.illegal.bad-comments-or-CDATA.xml']
 
   it "tokenizes empty element meta.tag.no-content.xml", ->
     {tokens} = grammar.tokenizeLine('<n></n>')

--- a/spec/xml-spec.coffee
+++ b/spec/xml-spec.coffee
@@ -25,19 +25,18 @@ describe "XML grammar", ->
     expect(lines[2][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(lines[3][1]).toEqual value: '<!--', scopes: ['text.xml', 'meta.tag.sgml.doctype.xml', 'meta.internalsubset.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
 
-  it 'tokenizes comment endings with more than two dashes as invalid', ->
+   it 'tokenizes comment endings with more than two dashes as invalid', ->
     {tokens} = grammar.tokenizeLine('<!-- invalid comment --->')
     expect(tokens[0]).toEqual value: '<!--', scopes: ['text.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(tokens[1]).toEqual value: ' invalid comment ', scopes: ['text.xml', 'comment.block.xml']
     expect(tokens[2]).toEqual value: '--', scopes: ['text.xml', 'comment.block.xml', 'invalid.illegal.bad-comments-or-CDATA.xml']
 
-  it 'tokenizes comments with two dashes not followed by ">"', ->
+  it 'tokenizes comments with two dashes not followed by ">" as invalid', ->
     {tokens} = grammar.tokenizeLine('<!-- invalid -- comment -->')
     expect(tokens[0]).toEqual value: '<!--', scopes: ['text.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
     expect(tokens[1]).toEqual value: ' invalid ', scopes: ['text.xml', 'comment.block.xml']
     expect(tokens[2]).toEqual value: '--', scopes: ['text.xml', 'comment.block.xml', 'invalid.illegal.bad-comments-or-CDATA.xml']
-    expect(tokens[3]).toEqual value: ' comment ', scopes: ['text.xml', 'comment.block.xml']
-    expect(tokens[4]).toEqual value: '-->', scopes: ['text.xml', 'comment.block.xml', 'punctuation.definition.comment.xml']
+    expect(tokens[3]).toEqual value: ' comment -->', scopes: ['text.xml', 'comment.block.xml']
 
   it "tokenizes empty element meta.tag.no-content.xml", ->
     {tokens} = grammar.tokenizeLine('<n></n>')


### PR DESCRIPTION
### Description of the Change

Any comment ending with more than 2 dashes is now considered as `invalid.illegal.bad-comments-or-CDATA.xml`

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits
Grammar no longer accepts `--->` comment ending that is forbidden by XML grammar.

### Possible Drawbacks

### Applicable Issues

#84 
