### PR TITLE
.nunit and .StyleCop are other XML file extensions

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -51,6 +51,7 @@
   'siml'
   'sld'
   'storyboard'
+  'StyleCop'
   'svg'
   'targets'
   'tld'

--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -34,6 +34,7 @@
   'launch'
   'menu'
   'mxml'
+  'nunit'
   'nuspec'
   'opml'
   'owl'


### PR DESCRIPTION
### Description of the Change
Just adding the [.StyleCop](https://github.com/StyleCop/StyleCop) and .nunit file extensions to the fileTypes array. If you want an example of the usage of the .StyleCop file extension, see the [OpenRA repository](https://github.com/OpenRA/OpenRA/blob/bleed/Settings.StyleCop). Likewise the OpenRA repository also has an example of a [.nunit file](https://github.com/OpenRA/OpenRA/blob/bleed/OpenRA.Test.nunit) that is in XML format.

### Benefits
This will make files with the .nunit and .StyleCop extensions syntax-highlighted as an XML file. 

### Possible Drawbacks
The only drawback I see is that maybe if the .nunit and .StyleCop file extensions are used by a different kind of file it may cause erroneous syntax-highlighting of said file, but this seems unlikely. 
