### PR TITLE
Add .kml extension

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -30,6 +30,7 @@
   'isml'
   'jmx'
   'jsp'
+  'kml'  
   'kst'
   'launch'
   'menu'


### PR DESCRIPTION
### Description of the Change

Add `.kml` as an XML file extension.

### Benefits

KML is an open standard officially named the OpenGIS® KML Encoding Standard (OGC KML). It is maintained by the Open Geospatial Consortium, Inc. (OGC). The complete specification for OGC KML can be found at http://www.opengeospatial.org/standards/kml/.
