### PR TITLE
Add support for GEXF files

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -21,6 +21,7 @@
   'fodt'
   'fsproj'
   'fxml'
+  'gexf'
   'gir'
   'glade'
   'gpx'


### PR DESCRIPTION
### Description of the Change

Update the grammar definition to add support for GEXF files (graphs).

### Benefits

GEXF can be edited with Atom, usign snippets defined for XML files. In fact, GEXF files are XML formated, with strictly defined tags, but remains XML.

### Possible Drawbacks

### Applicable Issues

