### PR TITLE
Fix for atom/language-xml#91 and atom/language-xml#96

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -406,8 +406,8 @@
         'captures':
           '0':
             'name': 'punctuation.definition.comment.xml'
-          'end': '--%>'
-          'name': 'comment.block.xml'
+        'end': '--%>'
+        'name': 'comment.block.xml'
       }
       {
         'begin': '<!--'
@@ -418,7 +418,7 @@
         'name': 'comment.block.xml'
         'patterns': [
           {
-            'begin': '--(?!>)'
+            'match': '--(?!>)'
             'captures':
               '0':
                 'name': 'invalid.illegal.bad-comments-or-CDATA.xml'


### PR DESCRIPTION
atom/language-xml#96 already provides all the details about the issues fixed here.

https://github.com/atom/language-xml/pull/87#issuecomment-401249754 has the correct code but merge included some extra indent which causes the rule not to work properly.

In relation with #91, a `begin` without `end` or `while` was added but this is not valid as `begin` should always have a corresponding `end` or `while`.  `match` should be used instead of `begin`

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.
* All new code requires tests to ensure against regressions

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

### Alternate Designs

<!-- Explain what other alternates were considered and why the proposed version was selected -->

### Benefits

<!-- What benefits will be realized by the code change? -->

### Possible Drawbacks

<!-- What are the possible side-effects or negative impacts of the code change? -->

### Applicable Issues

<!-- Enter any applicable Issues here -->
