### PR TITLE
Fixed indention error in xml grammar

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -30,7 +30,7 @@
   'isml'
   'jmx'
   'jsp'
-  'kml'  
+  'kml'
   'kst'
   'launch'
   'menu'
@@ -406,8 +406,8 @@
         'captures':
           '0':
             'name': 'punctuation.definition.comment.xml'
-          'end': '--%>'
-          'name': 'comment.block.xml'
+        'end': '--%>'
+        'name': 'comment.block.xml'
       }
       {
         'begin': '<!--'


### PR DESCRIPTION
### Description of the Change

Fixed indention error in the grammar for `<%--` style comments which cause them to not highlight properly.
