### PR TITLE
Fixed `<%--` `--%>` based comment `end` rule

### DIFF
--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -402,14 +402,6 @@
   'comments':
     'patterns': [
       {
-        'begin': '<%--'
-        'captures':
-          '0':
-            'name': 'punctuation.definition.comment.xml'
-        'end': '--%>'
-        'name': 'comment.block.xml'
-      }
-      {
         'begin': '<!--'
         'captures':
           '0':

--- a/grammars/xml.cson
+++ b/grammars/xml.cson
@@ -406,8 +406,8 @@
         'captures':
           '0':
             'name': 'punctuation.definition.comment.xml'
-          'end': '--%>'
-          'name': 'comment.block.xml'
+        'end': '--%>'
+        'name': 'comment.block.xml'
       }
       {
         'begin': '<!--'


### PR DESCRIPTION
`<%--` based commenting is broken because the `'end'` rule was indented twice too much
Fixed by removing the two extra 'space' indents for `'end'` and `'name'`

Broken comment:
![image](https://user-images.githubusercontent.com/33529441/148015902-6d80bcb7-d136-455a-9c61-d5bd8b5b5f1c.png)
Fixed comment:
![image](https://user-images.githubusercontent.com/33529441/148015934-c26047c5-33a9-4849-b1c1-f0876c410b1f.png)

Found this bug while looking at vscode extensions:
![image](https://user-images.githubusercontent.com/33529441/148016079-1bdbfe6b-2a0c-4a0c-982a-38988f3d9208.png)